### PR TITLE
Added meta information for distribution

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,4 +9,11 @@ Module::Build->new(
               },
   license => 'perl',
   create_makefile_pl => 'traditional',
+  meta_merge => {
+    resources => {
+            homepage   => 'https://metacpan.org/pod/Date::Holidays::DK',
+            bugtracker => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Date-Holidays-DK',
+            repository => 'https://github.com/tagg/Date-Holidays-DK',
+    }
+  },
 )->create_build_script;


### PR DESCRIPTION
Hi Lars, 

I have added meta information for distribution, specifying:
- homepage, pointing to meta.cpan.org
- repository, pointing to Github (took some time for me to locate it)
- bugtracker, pointing to rt.cpan.org
  
  Homepage could be http://search.cpan.org/~lthegler/Date-Holidays-DK/
  but the tendency seem to be moving to meta over search, it could
  also just be github, but that is specified for repository so it is
  locatable (especially via meta).
  
  Repository, is of course Github
  
  Bugtracker is pointing to RT, but could also be Github, but that is
  already specifed, so RT is a good candidate, unless you want to
  change the information flow.

I want to contribute some more, but this was just some low-hanging fruit for you to enjoy, 
use it if you like.

jonasbn
