### PR TITLE
Patched dk_holidays() and added more tests

### DIFF
--- a/DK.pm
+++ b/DK.pm
@@ -66,6 +66,12 @@ sub dk_holidays {
   # get the fixed dates
   my $h = {%$FIX};
 
+  if ($year >= 2024) {
+    $VAR = $VAR_POST2023;
+  } else {
+    $VAR = $VAR_PRE2024;
+  }
+
   my $easter = Date::Simple->new($year, easter($year));
 
   # build the relative dates

--- a/t/0_use.t
+++ b/t/0_use.t
@@ -1,5 +1,5 @@
 # -*- perl -*-
-use Test::More tests => 24;
+use Test::More tests => 26;
 use utf8;
 
 BEGIN {
@@ -34,11 +34,12 @@ sub t {
 }
 
 my $h;
-ok($h = dk_holidays(2004), 'call dk_holidays()');
+ok($h = dk_holidays(2004), 'call dk_holidays() for 2004');
 
 ok(eq_hash($h, {
   '0101' => "Nytårsdag",
   '0404' => "Palmesøndag",
+  '0507' => "Store Bededag",
   '0408' => "Skærtorsdag",
   '0409' => "Langfredag",
   '0411' => "Påskedag",
@@ -50,4 +51,22 @@ ok(eq_hash($h, {
   '1224' => "Juleaftensdag",
   '1225' => "Juledag",
   '1226' => "2. Juledag",
-}), 'check return values');
+}), 'check return values for 2004');
+
+ok($h = dk_holidays(2024), 'call dk_holidays() for 2024');
+
+ok(eq_hash($h, {
+  '0101' => "Nytårsdag",
+  '0324' => "Palmesøndag",
+  '0328' => "Skærtorsdag",
+  '0329' => "Langfredag",
+  '0331' => "Påskedag",
+  '0401' => "2. Påskedag",
+  '0509' => "Kristi Himmelfartsdag",
+  '0519' => "Pinsedag",
+  '0520' => "2. Pinsedag",
+  '0605' => "Grundlovsdag",
+  '1224' => "Juleaftensdag",
+  '1225' => "Juledag",
+  '1226' => "2. Juledag",
+}), 'check return values for 2024');


### PR DESCRIPTION
Hi @tagg 

As pointed out by @jixam in a comment on PR #2 the function: `dk_holidays` does not exercise the deprecation of "Store Bededag" as `is_dk_holiday`. 

This patch adds similar logic and additional tests to ensure that `dk_holidays` works as expected.

Sorry that I missed that